### PR TITLE
Compatibility with OGRE_RESOURCEMANAGER_STRICT

### DIFF
--- a/Dependencies/ImageConverter/src/imageconverter.cpp
+++ b/Dependencies/ImageConverter/src/imageconverter.cpp
@@ -84,9 +84,6 @@ ImageConverter::~ImageConverter()
 {
     mRttTex->removeAllViewports();
 
-    Ogre::TextureManager::getSingletonPtr()->unload(mRttTex->getName());
-    Ogre::TextureManager::getSingletonPtr()->remove(mRttTex->getName());
-
     Ogre::TextureManager::getSingletonPtr()->unload("RenderTex");
     Ogre::TextureManager::getSingletonPtr()->remove("RenderTex");
 

--- a/Dependencies/ImageConverter/src/imageconverter.cpp
+++ b/Dependencies/ImageConverter/src/imageconverter.cpp
@@ -84,8 +84,8 @@ ImageConverter::~ImageConverter()
 {
     mRttTex->removeAllViewports();
 
-    Ogre::TextureManager::getSingletonPtr()->unload("RenderTex");
-    Ogre::TextureManager::getSingletonPtr()->remove("RenderTex");
+    Ogre::TextureManager::getSingletonPtr()->unload("RenderTex", "QTImageConverter");
+    Ogre::TextureManager::getSingletonPtr()->remove("RenderTex", "QTImageConverter");
 
     Ogre::Root::getSingletonPtr()->destroySceneManager(mSceneMgrPtr);
     mResourceManager->destroyResourceGroup("QTImageConverter");

--- a/Ogitor/include/OgitorsUtils.h
+++ b/Ogitor/include/OgitorsUtils.h
@@ -196,12 +196,15 @@ namespace Ogitors
             *IndexBuffer = mIndexBuffer;
         }
         /**
-        * Get's a list of files in an OGRE resource
-        * @param resourceName the name of the OGRE resource to get the name list from
-        * @param resourceType optional parameter, whether the resource is from Ofs or FileSystem
-        * @param searchName optional parameter, will only return files that match this string
-        */
-        static Ogitors::PropertyOptionsVector GetResourceFilenames(const Ogre::String &resourceName, const Ogre::String resourceType="", const Ogre::String match="");
+         * Get's a list of files in an OGRE resource
+         * @param resourceName the name of the OGRE resource to get the name list from
+         * @param resourceType optional parameter, whether the resource is from Ofs or FileSystem
+         * @param searchName optional parameter, will only return files that match this string
+         * @param matchArchiveName optional parameter, will only return files that match this archive name
+         */
+        static Ogitors::PropertyOptionsVector
+        GetResourceFilenames(const Ogre::String& resourceName, const Ogre::String resourceType = "",
+                             const Ogre::String match = "", const Ogre::String matchArchiveName = "");
         /**
         * Frees internal vertex and index buffers
         */

--- a/Ogitor/src/MarkerEditor.cpp
+++ b/Ogitor/src/MarkerEditor.cpp
@@ -112,7 +112,7 @@ bool CMarkerEditor::unLoad()
 
     if(!mMaterial.isNull())
     {
-        Ogre::MaterialManager::getSingletonPtr()->remove(mMaterial->getName());
+        Ogre::MaterialManager::getSingletonPtr()->remove(mMaterial->getName(), mMaterial->getGroup());
     }
     
     return CNodeEditor::unLoad();

--- a/Ogitor/src/OgitorsRootUtilityFunctions.cpp
+++ b/Ogitor/src/OgitorsRootUtilityFunctions.cpp
@@ -1582,17 +1582,23 @@ void OgitorsRoot::ReloadUserResources()
 //-------------------------------------------------------------------------------------------
 void OgitorsRoot::PrepareTerrainResources()
 {
+    Ogre::String terrainDir = this->GetProjectOptions()->TerrainDirectory;
+    terrainDir = this->GetProjectFile()->getFileSystemName() + "::/" + terrainDir + "/";
+
     mTerrainDiffuseTextureNames.clear();
     mTerrainDiffuseTextureNames.push_back(PropertyOption("", Ogre::Any(Ogre::String(""))));
-    mTerrainDiffuseTextureNames = OgitorsUtils::GetResourceFilenames("TerrainGroupDiffuseSpecular", "Ofs");
+    mTerrainDiffuseTextureNames = OgitorsUtils::GetResourceFilenames(
+        "TerrainResources", "Ofs", "", terrainDir + "textures/diffusespecular");
 
     mTerrainNormalTextureNames.clear();
     mTerrainNormalTextureNames.push_back(PropertyOption("", Ogre::Any(Ogre::String(""))));
-    mTerrainNormalTextureNames = OgitorsUtils::GetResourceFilenames("TerrainGroupNormalHeight", "Ofs");
+    mTerrainNormalTextureNames = OgitorsUtils::GetResourceFilenames("TerrainResources", "Ofs", "",
+                                                                    terrainDir + "textures/normalheight");
 
     mTerrainPlantMaterialNames.clear();
     mTerrainPlantMaterialNames.push_back(PropertyOption("", Ogre::Any(Ogre::String(""))));
-    mTerrainPlantMaterialNames = OgitorsUtils::GetResourceFilenames("TerrainGroupPlants", "Ofs");
+    mTerrainPlantMaterialNames =
+        OgitorsUtils::GetResourceFilenames("TerrainResources", "Ofs", "", terrainDir + "plants");
 }
 //-------------------------------------------------------------------------------------------
 void OgitorsRoot::PrepareProjectResources()

--- a/Ogitor/src/OgitorsUtils.cpp
+++ b/Ogitor/src/OgitorsUtils.cpp
@@ -906,7 +906,10 @@ void OgitorsUtils::SphereQuery(const Ogre::Vector3& pos, Ogre::Real radius, Obje
     }
 }
 //----------------------------------------------------------------------------------------
-Ogitors::PropertyOptionsVector OgitorsUtils::GetResourceFilenames(const Ogre::String& resourceName, const Ogre::String resourceType, const Ogre::String match)
+Ogitors::PropertyOptionsVector OgitorsUtils::GetResourceFilenames(const Ogre::String& resourceName,
+                                                                  const Ogre::String resourceType,
+                                                                  const Ogre::String match,
+                                                                  const Ogre::String matchArchiveName)
 {
     Ogre::ResourceGroupManager *mngr = Ogre::ResourceGroupManager::getSingletonPtr();
     Ogre::FileInfoListPtr resList = Ogre::FileInfoListPtr();
@@ -926,6 +929,9 @@ Ogitors::PropertyOptionsVector OgitorsUtils::GetResourceFilenames(const Ogre::St
             continue;
 
         if (!match.empty() && fInfo.filename.find(match) == -1)
+            continue;
+
+        if (!matchArchiveName.empty() && fInfo.archive->getName() != matchArchiveName)
             continue;
 
         resourceList.push_back(PropertyOption(fInfo.filename, Ogre::Any(fInfo.filename)));

--- a/Ogitor/src/PlaneEditor.cpp
+++ b/Ogitor/src/PlaneEditor.cpp
@@ -59,7 +59,7 @@ Ogre::Entity *CPlaneEditor::_createPlane()
     {
         mPlaneHandle->detachFromParent();
         mPlaneHandle->_getManager()->destroyEntity(mPlaneHandle);
-        Ogre::MeshManager::getSingletonPtr()->remove(mName->get());        
+        Ogre::MeshManager::getSingletonPtr()->remove(mName->get(), PROJECT_RESOURCE_GROUP);
     }
 
     Ogre::Plane plane(mNormal->get(), mDistance->get());
@@ -261,7 +261,7 @@ bool CPlaneEditor::unLoad()
     {
         mPlaneHandle->detachFromParent();
         mPlaneHandle->_getManager()->destroyEntity(mPlaneHandle);
-        Ogre::MeshManager::getSingletonPtr()->remove(mName->get());        
+        Ogre::MeshManager::getSingletonPtr()->remove(mName->get(), PROJECT_RESOURCE_GROUP);
         mPlaneHandle = 0;
     }
     

--- a/Ogitor/src/TerrainGroupEditor.cpp
+++ b/Ogitor/src/TerrainGroupEditor.cpp
@@ -103,9 +103,6 @@ CTerrainGroupEditor::~CTerrainGroupEditor()
 {
     OGRE_DELETE mTerrainGlobalOptions;
     mOgitorsRoot->DestroyResourceGroup("TerrainResources");
-    mOgitorsRoot->DestroyResourceGroup("TerrainGroupNormalHeight");
-    mOgitorsRoot->DestroyResourceGroup("TerrainGroupDiffuseSpecular");
-    mOgitorsRoot->DestroyResourceGroup("TerrainGroupPlants");
 }
 //-----------------------------------------------------------------------------------------
 PGHeightFunction *CTerrainGroupEditor::getHeightFunction()
@@ -315,14 +312,13 @@ bool CTerrainGroupEditor::load(bool async)
     Ogre::String terrainDir = OgitorsRoot::getSingletonPtr()->GetProjectOptions()->TerrainDirectory;
     terrainDir = mOgitorsRoot->GetProjectFile()->getFileSystemName() + "::/" + terrainDir + "/";
 
-    mngr->addResourceLocation(terrainDir + "textures/normalheight", "Ofs", "TerrainGroupNormalHeight");
-    mngr->initialiseResourceGroup("TerrainGroupNormalHeight");
+    mngr->addResourceLocation(terrainDir + "textures/normalheight", "Ofs", "TerrainResources");
 
-    mngr->addResourceLocation(terrainDir + "textures/diffusespecular", "Ofs", "TerrainGroupDiffuseSpecular");
-    mngr->initialiseResourceGroup("TerrainGroupDiffuseSpecular");
+    mngr->addResourceLocation(terrainDir + "textures/diffusespecular", "Ofs", "TerrainResources");
 
-    mngr->addResourceLocation(terrainDir + "plants", "Ofs", "TerrainGroupPlants");
-    mngr->initialiseResourceGroup("TerrainGroupPlants");
+    mngr->addResourceLocation(terrainDir + "plants", "Ofs", "TerrainResources");
+
+    mngr->initialiseResourceGroup("TerrainResources");
 
     OgitorsRoot::getSingletonPtr()->PrepareTerrainResources();
     OgitorsRoot::getSingletonPtr()->ReloadUserResources();

--- a/Ogitor/src/TerrainMaterialGeneratorB.cpp
+++ b/Ogitor/src/TerrainMaterialGeneratorB.cpp
@@ -292,7 +292,7 @@ namespace Ogre
 			mat = matMgr.getByName(matName);
 			if (mat.isNull())
 			{
-				mat = matMgr.create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+				mat = matMgr.create(matName, terrain->_getDerivedResourceGroup());
 			}
 		}
 		// clear everything
@@ -341,7 +341,7 @@ namespace Ogre
 			mat = matMgr.getByName(matName);
 			if (mat.isNull())
 			{
-				mat = matMgr.create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+				mat = matMgr.create(matName, terrain->_getDerivedResourceGroup());
 			}
 		}
 		// clear everything

--- a/Ogitor/src/TerrainMaterialGeneratorC.cpp
+++ b/Ogitor/src/TerrainMaterialGeneratorC.cpp
@@ -280,7 +280,7 @@ namespace Ogre
 			mat = matMgr.getByName(matName);
 			if (mat.isNull())
 			{
-				mat = matMgr.create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+				mat = matMgr.create(matName, terrain->_getDerivedResourceGroup());
 			}
 		}
 		// clear everything
@@ -319,7 +319,7 @@ namespace Ogre
 			mat = matMgr.getByName(matName);
 			if (mat.isNull())
 			{
-				mat = matMgr.create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+				mat = matMgr.create(matName, terrain->_getDerivedResourceGroup());
 			}
 		}
 		// clear everything

--- a/Ogitor/src/TerrainPageEditorGrass.cpp
+++ b/Ogitor/src/TerrainPageEditorGrass.cpp
@@ -238,7 +238,8 @@ void CTerrainPageEditor::_unloadGrassLayers()
 
     mPGDensityMap.freeMemory();
 
-    Ogre::TextureManager::getSingletonPtr()->remove(mName->get() + "_densitymap");
+    Ogre::TextureManager::getSingletonPtr()->remove(mName->get() + "_densitymap",
+                                                    PROJECT_TEMP_RESOURCE_GROUP);
 
     Ogre::AxisAlignedBox bBox = mHandle->getWorldAABB();
     TBounds bounds(bBox.getMinimum().x, bBox.getMinimum().z, bBox.getMaximum().x, bBox.getMaximum().z);

--- a/Plugins/OgModularZone/PortalEditor.cpp
+++ b/Plugins/OgModularZone/PortalEditor.cpp
@@ -359,7 +359,7 @@ Ogre::Entity* PortalEditor::_createPlane()
     {
         mPlaneHandle->detachFromParent();
         mPlaneHandle->_getManager()->destroyEntity(mPlaneHandle);
-        Ogre::MeshManager::getSingletonPtr()->remove(mName->get());
+        Ogre::MeshManager::getSingletonPtr()->remove(mName->get(), PROJECT_RESOURCE_GROUP);
     }
 
     Ogre::Plane plane(Ogre::Vector3::UNIT_Z, 0.0);

--- a/qtOgitor/src/main.cpp
+++ b/qtOgitor/src/main.cpp
@@ -48,9 +48,6 @@
 
 #include <QtWidgets/QSplashScreen>
 
-#if OGRE_RESOURCEMANAGER_STRICT != 0
-#error "Ogitor is not yet compatible with STRICT mode, use PEDANTIC mode (=1) for fixing"
-#endif
 
 #if OGRE_THREAD_PROVIDER != 0
 #error "Ogitor is not yet compatible with Ogre threading"

--- a/qtOgitor/src/qtogitorsystem.cpp
+++ b/qtOgitor/src/qtogitorsystem.cpp
@@ -712,9 +712,9 @@ bool QtOgitorSystem::DisplayCalculateBlendMapDialog(Ogre::NameValuePairList &par
         {
             Ogitors::PropertyOption opt = (*diffItr);
             Ogre::String name = Ogre::any_cast<Ogre::String>(opt.mValue);
-            
+
             QPixmap pixmap;
-            if (!pixmap.convertFromImage(imageConverter.fromOgreImageName(name, "TerrainGroupDiffuseSpecular")))
+            if (!pixmap.convertFromImage(imageConverter.fromOgreImageName(name, "TerrainResources")))
                 continue;
 
             QIcon witem(pixmap);

--- a/qtOgitor/src/terraintoolswidget.cpp
+++ b/qtOgitor/src/terraintoolswidget.cpp
@@ -272,9 +272,9 @@ void TerrainToolsWidget::populateTextures()
     {
         Ogitors::PropertyOption opt = (*diffItr);
         Ogre::String name = Ogre::any_cast<Ogre::String>(opt.mValue);
-        
+
         QPixmap pixmap;
-        if (!pixmap.convertFromImage(imageConverter.fromOgreImageName(name, "TerrainGroupDiffuseSpecular")))
+        if (!pixmap.convertFromImage(imageConverter.fromOgreImageName(name, "TerrainResources")))
             continue;
 
         QListWidgetItem *witem = new QListWidgetItem(QIcon(pixmap), name.c_str());
@@ -299,15 +299,30 @@ void TerrainToolsWidget::populatePlants()
     while (list.hasMoreElements())
     {
         Ogre::ResourcePtr resPtr = list.getNext();
-        if (resPtr->getGroup() != "TerrainGroupPlants")
+        if (resPtr->getGroup() != "TerrainResources")
             continue;
+
+        bool found = false;
+        for (PropertyOptionsVector::iterator it = plantList->begin(); it != plantList->end(); it++)
+        {
+            if (it->mKey == resPtr->getOrigin())
+            {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found)
+        {
+            continue;
+        }
 
         Ogre::String name = resPtr->getName();
 
         QPixmap pixmap;
-        if (!pixmap.convertFromImage(imageConverter.fromOgreMaterialName(name, "TerrainGroupPlants")))
+        if (!pixmap.convertFromImage(imageConverter.fromOgreMaterialName(name, "TerrainResources")))
             continue;
-        
+
         QListWidgetItem *witem = new QListWidgetItem(QIcon(pixmap), name.c_str());
         witem->setWhatsThis(name.c_str());
         witem->setToolTip(name.c_str());


### PR DESCRIPTION
I did some changes to solve #11.
It works but I still would want to change 6fc5be6842bde87243065e8bdd0b72f491c982dc because it is a workaround/hack.
The terrain itself uses the resource group `TerrainResources` but the layer textures are using the resource groups `TerrainGroupDiffuseSpecular`/`TerrainGroupNormalHeight`.
When trying to find them, the resource group of the terrain is used, which does not work with the layer textures in different groups.

One could either move all the textures into the `TerrainResources` group or add the resource groups to the layer textures in the Terrain class instead.

However, I don't know which one is the most convenient way here.