### PR TITLE
image load correction and correction dump splatting with an unassigned texture

### DIFF
--- a/Ogitor/src/TerrainGroupEditorEditing.cpp
+++ b/Ogitor/src/TerrainGroupEditorEditing.cpp
@@ -301,6 +301,14 @@ void CTerrainGroupEditor::setTexture(const Ogre::String& texture)
     {
         mTextureNormal = mTextureDiffuse.substr(pos + 1,mTextureDiffuse.length() - pos + 1);
         mTextureDiffuse = mTextureDiffuse.erase(pos,mTextureDiffuse.length() - pos);
+        
+        if (!mTextureNormal.empty())
+        {
+            Ogre::ResourceGroupManager* mngr = Ogre::ResourceGroupManager::getSingletonPtr();
+            if (!mngr->findResourceNames("TerrainResources", mTextureNormal))
+                mTextureNormal = Ogre::StringUtil::BLANK;
+        }
+        
     }
 }
 //-----------------------------------------------------------------------------------------

--- a/Ogitor/src/TerrainGroupEditorImportExport.cpp
+++ b/Ogitor/src/TerrainGroupEditorImportExport.cpp
@@ -95,7 +95,7 @@ void CTerrainGroupEditor::importFullTerrainFromHeightMap()
         Ogre::DataStreamPtr stream = Ogre::DataStreamPtr(OGRE_NEW Ogre::FileStreamDataStream(&fstr, false));
 
         Ogre::Image img;
-        img.load(stream);
+        img.load(stream,"png");
 
         data = OGRE_ALLOC_T(float, img.getWidth() * img.getHeight(), Ogre::MEMCATEGORY_GEOMETRY);
         Ogre::PixelBox pb(img.getWidth(), img.getHeight(), 1, Ogre::PF_FLOAT32_R, data);

--- a/Ogitor/src/TerrainPageEditor.cpp
+++ b/Ogitor/src/TerrainPageEditor.cpp
@@ -465,6 +465,8 @@ int CTerrainPageEditor::_getLayerID(Ogre::String& texture, Ogre::String& normal,
     }
     if(layerID == -1 && !dontcreate)
     {
+        if (normal.empty())
+            return layerID;
         layerID = _createNewLayer(texture, normal);
     }
     return layerID;

--- a/Ogitor/src/TerrainPageEditor.cpp
+++ b/Ogitor/src/TerrainPageEditor.cpp
@@ -1554,7 +1554,7 @@ CBaseEditor *CTerrainPageEditorFactory::CreateObject(CBaseEditor **parent, Ogito
 
     if ((ni = params.find("externaldatahandle")) != params.end())
     {
-        object->mExternalDataHandle = (float*)(Ogre::any_cast<unsigned long>(ni->second.val));
+        object->mExternalDataHandle = Ogre::any_cast<float*>(ni->second.val);
     }
 
     object->createProperties(params);

--- a/Ogitor/src/TerrainPageEditorImportExport.cpp
+++ b/Ogitor/src/TerrainPageEditorImportExport.cpp
@@ -194,7 +194,7 @@ bool CTerrainPageEditor::importHeightMap(Ogre::String filename, Ogre::Real fBias
         Ogre::DataStreamPtr stream = Ogre::DataStreamPtr(OGRE_NEW Ogre::FileStreamDataStream(&fstr, false));
 
         Ogre::Image img;
-        img.load(stream);
+        img.load(stream,"png");
         img.resize(mHandle->getSize(), mHandle->getSize());
         
         if(flipV)

--- a/qtOgitor/src/terraintoolswidget.cpp
+++ b/qtOgitor/src/terraintoolswidget.cpp
@@ -278,6 +278,11 @@ void TerrainToolsWidget::populateTextures()
             continue;
 
         QListWidgetItem *witem = new QListWidgetItem(QIcon(pixmap), name.c_str());
+        
+        Ogre::String namenormal = Ogre::StringUtil::replaceAll(name, "diffusespecular", "normalheight");
+        name.append(";");
+        name.append(namenormal);        
+        
         witem->setWhatsThis(name.c_str());
         witem->setToolTip(name.c_str());
         texturesWidget->addItem(witem);


### PR DESCRIPTION
two corrections;

1.  it was not possible load the png height files without adding specifiying the image format in the image::load function.
2. splat return error when the texture selected was still not assigned to a layer (so program try to add a new layer). The normal map associated to the diffuse map selected was not ready, so the resource load return an exception. The original code assumes the normal map name is concatenated to the diffuse map name with a ";" as separator in the widget, so I changed using this logic